### PR TITLE
Allow mediawiki table prefixes to be honoured at creation

### DIFF
--- a/cache.sql
+++ b/cache.sql
@@ -1,10 +1,10 @@
-CREATE TABLE IF NOT EXISTS `bugzilla_cache` (
+CREATE TABLE IF NOT EXISTS /*$wgDBprefix*/bugzilla_cache (
   `id` integer(40) NOT NULL AUTO_INCREMENT,
   `key` varchar(255) NOT NULL DEFAULT '',
   `fetched_at` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
   `data` longtext,
   `expires` integer(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB, DEFAULT CHARSET=binary;
+) /*$wgDBTableOptions*/;
 
-CREATE UNIQUE INDEX `key_unique` ON `bugzilla_cache` (`key`);
+CREATE UNIQUE INDEX /*i*/key_unique ON /*_*/bugzilla_cache (`key`);


### PR DESCRIPTION
In it's current form, the extension does not comply, and therefore doesn't create table and index prefixes. If MySQL is used as the caching source, the queries would be attempted on the prefixed version, which of course won't exist.

Aaaand, hard coding engine and charset could cause other trouble.
