### PR TITLE
Don't specify table styles for list display

### DIFF
--- a/templates/bug/list.tpl
+++ b/templates/bug/list.tpl
@@ -1,4 +1,4 @@
-<ul class="bugzilla ui-helper-reset">
+<ul>
     <?php
         $base = dirname(__FILE__) . '/../../templates/fields/';
 


### PR DESCRIPTION
The .bugzilla and .ui-helper-reset classes are useful for table display. However, when using list display, these styles make the resulting list look very out of place in a wiki page. For example, in [this wiki page](https://wiki.mozilla.org/Mobile/Notes/18-Dec-2013#mcomella), the generated list has a border and smaller font; removing those styles makes the list look the same as the other lists.
