### PR TITLE
Fix js error that breaks table sorting (bug 858844)

### DIFF
--- a/Bugzilla.php
+++ b/Bugzilla.php
@@ -69,6 +69,7 @@ function BugzillaCreateCache($updater) {
 function BugzillaIncludeHTML( &$out, &$sk ) {
 
     global $wgScriptPath;
+    global $wgVersion;
     global $wgBugzillaJqueryTable;
     global $wgBugzillaTable;
 


### PR DESCRIPTION
Load jquery libraries only for mw versions prior to 1.17. Fixes tablesort error (https://bugzilla.mozilla.org/show_bug.cgi?id=858844).
