### PR TITLE
Fix end-of-table calculations

### DIFF
--- a/templates/bug/table.tpl
+++ b/templates/bug/table.tpl
@@ -66,4 +66,4 @@
     </tbody>
 </table>
 
-<strong><?php echo($all-$resolved) ?> Open; <?php echo($resolved) ?> Resolved; <?php echo($all) ?> Total (<?php echo 100*(round($resolved/$all, 4)) ?>% complete)</strong>
+<strong><?php echo $all-$resolved ?> Open; <?php echo $resolved ?> Resolved; <?php echo $all ?> Total (<?php echo 100*(round($resolved/$all, 4)) ?>% complete)</strong>


### PR DESCRIPTION
1) Open, Resolved, and All counters were not shown.

2) Resolved counter did not include "VERIFIED" bugs, which should be considered a type of resolved.
