### PR TITLE
Fix divide-by-zero error

### DIFF
--- a/templates/bug/table.tpl
+++ b/templates/bug/table.tpl
@@ -66,4 +66,4 @@
     </tbody>
 </table>
 
-<strong><?php echo $all-$resolved ?> Open; <?php echo $resolved ?> Resolved; <?php echo $all ?> Total (<?php echo 100*(round($resolved/$all, 4)) ?>% complete)</strong>
+<strong><?php echo $all-$resolved ?> Open; <?php echo $resolved ?> Resolved; <?php echo $all ?> Total (<?php if ($all != 0) echo 100*(round($resolved/$all, 4)); else echo 0 ?>% complete)</strong>


### PR DESCRIPTION
Silly case when a search returns no results. Minimal visual impact, but reduces error_log volume and cuts out the largest error reported in New Relic.
