### PR TITLE
Prevent jquery datatable from overriding the initial sort order

### DIFF
--- a/Bugzilla.php
+++ b/Bugzilla.php
@@ -114,6 +114,8 @@ function BugzillaIncludeHTML( &$out, &$sk ) {
             "bJQueryUI": true,
             "aLengthMenu": ' . $wgBugzillaTable['lengthMenu'] . ',
             "iDisplayLength" : ' . $wgBugzillaTable['pageSize'] . ',
+            /* Disable initial sort */
+            "aaSorting": [],
             })});'
         );
     }


### PR DESCRIPTION
This fixes https://github.com/mozilla/mediawiki-bugzilla/issues/43 , as suggested by http://stackoverflow.com/questions/4964388/is-there-a-way-to-disable-initial-sorting-for-jquery-datatables
