### PR TITLE
Bug 1168463 - Add an option to hide bug resolution statistics

### DIFF
--- a/Bugzilla.class.php
+++ b/Bugzilla.class.php
@@ -20,6 +20,7 @@ class Bugzilla {
         $theconfig = array(
             'type'    => 'bug',
             'display' => 'table',
+            'stats' => 'show',
         );
 
         // Overlay user's desired configuration

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ By default, it will output a colored table:
 Note that the wiki tag name defaults to "bugzilla" but is 
 configurable by the administrator.
 
+Options
+================================
+
+Valid bugzilla tag options are:
+
+* type: ``"bug"`` or ``"count"`` (defaults to bug)
+* For type bug:
+    * display: ``"table"`` or ``"list"`` (defaults to table)
+* For type count:
+    * display: ``"bar"`` or ``"pie"``
+    * size: ``"small"``, ``medium"`` or ``"large"`` (defaults to large)
+* stats: ``"show"`` or ``"hide"`` (defaults to "show")
+
+
 Examples
 ================================
 
@@ -67,9 +81,10 @@ All new bugs flagged as uiwanted in the whiteboard:
         }
     </bugzilla>
 
-All bugs in the bugzilla.org component that were resolved in 2011:	
+All bugs in the bugzilla.org component that were resolved in 2011,
+with the stats summary hidden:	
 
-    <bugzilla>
+    <bugzilla stats="hide">
         {
             "component": "bugzilla.org",
             "changed_after": "2011-01-01",

--- a/templates/bug/table.tpl
+++ b/templates/bug/table.tpl
@@ -70,9 +70,15 @@
     </tbody>
 </table>
 
+<?php
+if ($this->config['stats'] == 'show') {
+?>
 <strong>
 <?php echo $all ?> Total;
 <?php echo $all-$resolved-$verified ?> Open (<?php if ($all != 0) echo 100*(round(($all-$resolved-$verified)/$all, 4)); else echo 0 ?>%);
 <?php echo $resolved ?> Resolved (<?php if ($all != 0) echo 100*(round(($resolved)/$all, 4)); else echo 0 ?>%);
 <?php echo $verified ?> Verified (<?php if ($all != 0) echo 100*(round(($verified)/$all, 4)); else echo 0 ?>%);
 </strong>
+<?php
+}
+?>


### PR DESCRIPTION
This adds the ability to turn off the bug resolution statistics, eg:
``44 Total; 0 Open (0%); 40 Resolved (90.91%); 4 Verified (9.09%);``

Using a new "stats" option:
```html
  <bugzilla stats="hide">
    ...
  </bugzilla>
```

Fixes #55.