### PR TITLE
Bug 1168491 - Make people fields less verbose if real name set

### DIFF
--- a/templates/fields/people.tpl
+++ b/templates/fields/people.tpl
@@ -20,10 +20,8 @@
 
         if( empty($rn) ) {
             $out = $n;
-        }elseif( empty($n) ) {
-            $out = $rn;
         }else {
-            $out = "$rn ($n)";
+            $out = $rn;
         }
 
         // Special case for "nobody"


### PR DESCRIPTION
Previously if the real name was set, both the name (ie partial email address) and real name was displayed, now only the real name is shown.