### PR TITLE
Add json rpc support

### DIFF
--- a/BugzillaOutput.class.php
+++ b/BugzillaOutput.class.php
@@ -89,7 +89,11 @@ class BugzillaBugListing extends BugzillaOutput {
         if( isset($this->query->options['include_fields']) &&
             !empty($this->query->options['include_fields']) ) {
             // User specified some fields
-            $tmp = @explode(',', $this->query->options['include_fields']);
+            if (!is_array($this->query->options['include_fields'])) {
+                $tmp = @explode(',', $this->query->options['include_fields']);
+            } else {
+                $tmp = &$this->query->options['include_fields'];
+            }
             foreach( $tmp as $tmp_field ) {
                 $field = trim($tmp_field);
                 // Catch if the user specified the same field multiple times

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ and b) display those columns.
     <bugzilla>
     {
         "whiteboard": "[mediawiki-bugzilla]",
-        "include_fields": "id, summary, whiteboard, status, resolution"
+        "include_fields": ["id", "summary", "whiteboard", "status", "resolution"]
     }
     </bugzilla>
 

--- a/cache/BugzillaCacheSql.class.php
+++ b/cache/BugzillaCacheSql.class.php
@@ -78,11 +78,19 @@ class BugzillaCacheSql implements BugzillaCacheI
     public function expire($key)
     {
         $master = $this->_getDatabase();
+        global $wgBugzillaCacheType;
 
-        return $master->delete(
-            'bugzilla_cache',
-            array('key' => $key)
-        );
+        if ($wgBugzillaCacheType == 'mysql') {
+            return $master->delete(
+                'bugzilla_cache',
+                array('`key`="' . $key . '"')
+            );
+        } else {
+            return $master->delete(
+                'bugzilla_cache',
+                array('key' => $key)
+            );
+        }
     }
 
     /**

--- a/cache/BugzillaCacheSql.class.php
+++ b/cache/BugzillaCacheSql.class.php
@@ -81,7 +81,7 @@ class BugzillaCacheSql implements BugzillaCacheI
 
         return $master->delete(
             'bugzilla_cache',
-            array('`key`="' . $key . '"')
+            array('key' => $key)
         );
     }
 

--- a/cache/sql/postgresql.sql
+++ b/cache/sql/postgresql.sql
@@ -1,6 +1,6 @@
 CREATE TABLE bugzilla_cache (
-    `id`          SERIAL PRIMARY KEY,
-    `key`         VARCHAR(255) UNIQUE NOT NULL DEFAULT '',
-    `data`        TEXT,
-    `expires`     INTEGER NOT NULL DEFAULT 0
+    id          SERIAL PRIMARY KEY,
+    key         VARCHAR(255) UNIQUE NOT NULL DEFAULT '',
+    data        TEXT,
+    expires     INTEGER NOT NULL DEFAULT 0
 );


### PR DESCRIPTION
The appended commits adds json rpc support. It uses the mw build-in http functions to retrieve the json data.