### PR TITLE
Set a user agent when querying remote API

### DIFF
--- a/Bugzilla.php
+++ b/Bugzilla.php
@@ -18,12 +18,15 @@
  * Application metadata and credits. Should not be changed.
  */
 
+$wgBugzillaExtVersion = '1.0.0';
+
 $wgExtensionCredits['other'][] = array(
     'name'        => 'Bugzilla',
     'author'      => 'Christian Legnitto',
     'url'         => 'https://github.com/LegNeato/mediawiki-bugzilla',
     'descriptionmsg' => 'bugzilla-desc',
-    'license-name' => 'MPL2'
+    'license-name' => 'MPL2',
+    'version'     => $wgBugzillaExtVersion;
 );
 
 $wgResourceModules['ext.Bugzilla'] = array(

--- a/BugzillaQuery.class.php
+++ b/BugzillaQuery.class.php
@@ -182,6 +182,15 @@ class BugzillaRESTQuery extends BugzillaBaseQuery {
         $this->fetch();
     }
 
+    public function user_agent() {
+        global $wgBugzillaExtVersion;
+        global $wgVersion;
+
+        return 'MediawikiBugzilla/'.$wgBugzillaExtVersion
+            .' MediaWiki/'.$wgVersion
+            .' PHP/'.PHP_VERSION;
+    }
+
     // Load data from the Bugzilla REST API
     public function _fetch_by_options() {
 
@@ -202,6 +211,7 @@ class BugzillaRESTQuery extends BugzillaBaseQuery {
         // The REST API requires these
         $request->setHeader('Accept', 'application/json');
         $request->setHeader('Content-Type', 'application/json');
+        $request->setHeader('User-Agent', $this->user_agent());
 
         // Save the real options
         $saved_options = $this->options;


### PR DESCRIPTION
See: https://github.com/mozilla/mediawiki-bugzilla/issues/84

A $wgBugzillaExtVersion is defined as a global, used by a new BugzillaRESTQuery::user_agent() method.

Initial version is arbitrarily set at 1.0.0 to begin with, but that, and the versioning scheme to adopt, is left to discussion (I'd suggest http://semver.org).