### PR TITLE
Refactor consistent options

### DIFF
--- a/Bugzilla.php
+++ b/Bugzilla.php
@@ -166,6 +166,7 @@ function BugzillaRender($input, array $args, Parser $parser, $frame=null ) {
     $bz = Bugzilla::create($args, $input, $parser->getTitle());
 
     // Show the desired output (or an error if there was one)
+    $bz->fetch();
     return $bz->render();
 }
 

--- a/BugzillaOutput.class.php
+++ b/BugzillaOutput.class.php
@@ -11,13 +11,7 @@ abstract class BugzillaOutput {
         $this->error    = false;
         $this->response = new stdClass();
 
-        // Make our query and possibly fetch the data
         $this->query = BugzillaQuery::create($config['type'], $options, $title);
-
-        // Bubble up any query errors
-        if( $this->query->error ) {
-            $this->error = $this->query->error;
-        }
     }
 
     protected function _render_error($error) {
@@ -27,7 +21,15 @@ abstract class BugzillaOutput {
         return ob_get_clean();
     }
 
+    public function fetch() {
+        $this->query->fetch();
+    }
+
     public function render() {
+        if( $this->query->error ) {
+            return $this->_render_error($this->query->error);
+        }
+
         // Get our template path
         $this->template = dirname(__FILE__) . '/templates/' .
                           $this->config['type'] . '/' .
@@ -42,8 +44,6 @@ abstract class BugzillaOutput {
                            ' combination';
         }
 
-        // If there are any errors (either from the template path above or
-        // elsewhere) output them
         if( $this->error ) {
             return $this->_render_error($this->error);
         }

--- a/BugzillaOutput.class.php
+++ b/BugzillaOutput.class.php
@@ -85,28 +85,7 @@ class BugzillaBugListing extends BugzillaOutput {
             $this->response->bugs = $this->query->data['bugs'];
         }
 
-        // Set the field data for the templates
-        if( isset($this->query->options['include_fields']) &&
-            !empty($this->query->options['include_fields']) ) {
-            // User specified some fields
-            if (!is_array($this->query->options['include_fields'])) {
-                $tmp = @explode(',', $this->query->options['include_fields']);
-            } else {
-                $tmp = &$this->query->options['include_fields'];
-            }
-            foreach( $tmp as $tmp_field ) {
-                $field = trim($tmp_field);
-                // Catch if the user specified the same field multiple times
-                if( !empty($field) &&
-                    !in_array($field, $this->response->fields) ) {
-                    array_push($this->response->fields, $field);
-                }
-            }
-        }else {
-            // If the user didn't specify any fields in the query config use
-            // default fields
-            $this->response->fields = $wgBugzillaDefaultFields;
-        }
+        $this->response->fields = $this->query->options['include_fields'];
     }
 
 }

--- a/BugzillaQuery.class.php
+++ b/BugzillaQuery.class.php
@@ -178,8 +178,6 @@ class BugzillaRESTQuery extends BugzillaBaseQuery {
                 // Even if the user didn't specify, we need these
                 $this->synthetic_fields = $wgBugzillaDefaultFields;
         }
-
-        $this->fetch();
     }
 
     public function user_agent() {
@@ -293,8 +291,6 @@ class BugzillaJSONRPCQuery extends BugzillaBaseQuery {
                 $this->synthetic_fields = $wgBugzillaDefaultFields;
                 break;
         }
-
-        $this->fetch();
     }
 
     // Load data from the Bugzilla JSONRPC API
@@ -360,8 +356,6 @@ class BugzillaXMLRPCQuery extends BugzillaBaseQuery {
         parent::__construct($type, $options, $title);
 
         $this->url = $wgBugzillaURL . '/xmlrpc.cgi';
-
-        $this->fetch();
     }
 
     // Load data from the Bugzilla XMLRPC API

--- a/tests/phpunit/BugzillaQueryTest.php
+++ b/tests/phpunit/BugzillaQueryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+require '../../Bugzilla.class.php';
+require '../../BugzillaQuery.class.php';
+
+class BugzillaQueryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider prepareOptionsProvider
+     *
+     * @param string $json     JSON options structure defined in <bugzilla /> element.
+     * @param array  $default  default fields to include in query
+     * @param array  $expected resulting options array
+    */
+    public function testPrepareOptions($json, $default, $expected)
+    {
+        $q = BugzillaQuery::create('bug', $json, 'title');
+        $this->assertEquals($expected, $q->prepare_options($json, $default));
+    }
+
+    public function prepareOptionsProvider()
+    {
+        $default_includes = ['incA', 'incB'];
+        return [
+            [
+                '',
+                [],
+                ['include_fields' => []]
+            ],
+            [
+                '{"other":"options"}',
+                $default_includes,
+                [
+                    'include_fields' => $default_includes,
+                    'other' => 'options'
+                ]
+            ],
+            [
+                '{"include_fields": ["C"]}',
+                $default_includes,
+                [
+                    'include_fields' => ['C']
+                ]
+            ],
+            [
+                '{"include_fields": ["json", "array"]}',
+                $default_includes,
+                [
+                    'include_fields' => ['json', 'array']
+                ]
+            ],
+            [
+                '{"include_fields": "json,string"}',
+                $default_includes,
+                [
+                    'include_fields' => ['json', 'string']
+                ]
+            ],
+            [
+                'invalid JSON',
+                $default_includes,
+                null
+            ]
+        ];
+    }
+
+    public function testPrepareOptionsError()
+    {
+        $q = BugzillaQuery::create('bug', 'invalid JSON', 'title');
+        $this->assertEquals(null, $q->prepare_options('invalid JSON', ['A', 'B']));
+        $this->assertEquals('Query options must be valid JSON.', $q->error);
+    }
+
+}

--- a/tests/phpunit/BugzillaQueryTest.php
+++ b/tests/phpunit/BugzillaQueryTest.php
@@ -71,4 +71,22 @@ class BugzillaQueryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Query options must be valid JSON.', $q->error);
     }
 
+    /**
+     * @dataProvider rebaseFieldsProvider
+    */
+    public function testRebaseFields($request, $synthetic, $expected)
+    {
+        $q = BugzillaQuery::create('bug', '{}', 'title');
+        $this->assertEquals($expected, $q->rebase_fields($request, $synthetic));
+    }
+
+    public function rebaseFieldsProvider()
+    {
+        return [
+            [ ['A', 'B', 'C'], ['A', 'B'], ['A', 'B', 'C'] ],
+            [ ['A'],           ['A', 'B'], ['A', 'B']      ],
+            [ ['C'],           ['B', 'A'], ['A', 'B', 'C'] ],
+        ];
+    }
+
 }

--- a/tests/phpunit/BugzillaQueryTest.php
+++ b/tests/phpunit/BugzillaQueryTest.php
@@ -28,6 +28,11 @@ class BugzillaQueryTest extends PHPUnit_Framework_TestCase
                 ['include_fields' => []]
             ],
             [
+                " { \n } ",
+                ['default'],
+                ['include_fields' => ['default']]
+            ],
+            [
                 '{"other":"options"}',
                 $default_includes,
                 [
@@ -60,7 +65,7 @@ class BugzillaQueryTest extends PHPUnit_Framework_TestCase
                 'invalid JSON',
                 $default_includes,
                 null
-            ]
+            ],
         ];
     }
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+date_default_timezone_set('Europe/Paris');

--- a/tests/phpunit/phpunit.xml
+++ b/tests/phpunit/phpunit.xml
@@ -1,0 +1,29 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="bootstrap.php"
+    cacheTokens="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    strict="true"
+    verbose="true">
+    <testsuites>
+        <testsuite name="mediawiki-bugzilla">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+    <logging>
+      <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
+      <log type="coverage-html" target="coverage"/>
+      <log type="tap" target="php://stdout"/>
+    </logging>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+          <directory suffix=".php">../../</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
`$options` is manipulated several times in the query class and sub-classes: injecting synthetic fields before querying cache/web service, making sure it is set, etc. This makes several unnecessary duplicates and shows uncertainty about how `$options` should look like.

This PR introduces, in order of impact:
- new `prepare_options()`, that's used to initialize the `$options`; later methods don't have to guess anymore; this should fix #18 as well;
- new `rebase_fields()` which replaces most duplicated code with a single, easier to read function;
- new `rebased_options()` which returns `$options` content + specific arrangements for HTTP queries;
- tests for above methods;
- when no JSON configuration is provided in the `<bugzilla>` element, a default working configuration is used, instead of triggering an error.

I am not so sure about:
- the naming of the methods introduced: `prepare_options`, `rebase_fields`, `rebased_options`;
- I moved `fetch()` out of the constructors to help testing objects behavior. It's now triggered through `BugzillaOutput`;
- the exact default failover configuration: I think it's good to set a working default but maybe the default query could be more specific than this one.
