### PR TITLE
Add a link to the Bugzilla query in the table summary

### DIFF
--- a/BugzillaOutput.class.php
+++ b/BugzillaOutput.class.php
@@ -79,6 +79,7 @@ class BugzillaBugListing extends BugzillaOutput {
 
         $this->response->bugs   = array();
         $this->response->fields = array();
+        $this->response->full_query_url = $this->query->full_query_url();
 
         // Set the bug data for the templates
         if(isset($this->query->data['bugs']) && count($this->query->data['bugs']) > 0) {

--- a/BugzillaQuery.class.php
+++ b/BugzillaQuery.class.php
@@ -152,6 +152,11 @@ abstract class BugzillaBaseQuery {
         $cache->set($this->id(), base64_encode(serialize($this->data)));
     }
 
+    public function full_query_url()
+    {
+        global $wgBugzillaURL;
+        return $wgBugzillaURL . '/buglist.cgi?' . http_build_query($this->options);
+    }
 }
 
 class BugzillaRESTQuery extends BugzillaBaseQuery {

--- a/templates/bug/table.tpl
+++ b/templates/bug/table.tpl
@@ -3,6 +3,9 @@
     $extra_class = ($wgBugzillaJqueryTable) ? 'jquery ui-helper-reset' : '';
 ?>
 <table class="wikitable sortable bugzilla <?php echo $extra_class ?>">
+    <summary>
+      <?php echo '<a href="', $response->full_query_url, '">Full Query</a>'; ?>
+    </summary>
     <thead>
         <tr>
         <?php


### PR DESCRIPTION
This is not perfect:
- adding the link before or after the table makes it moved by the datatable controls;
- adding it in the table summary makes a bit more sense, but it is moved still.

But that's a start.

Fixes: #45
