### PR TITLE
Define code style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.sw*
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+
+
+install-dev:
+	composer install
+
+test: lint cs
+
+lint: phplint
+
+cs: phpcs
+
+phplint:
+	./vendor/bin/parallel-lint --exclude vendor/ .
+
+phpcs:
+	./vendor/bin/phpcs -p --colors .
+
+phpcsfix:
+	./vendor/bin/phpcbf .
+
+.PHONY: test lint cs phpcs phplint phpcsfix

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+	"require-dev": {
+		"jakub-onderka/php-parallel-lint": "0.9.2",
+		"mediawiki/mediawiki-codesniffer": "0.7.2"
+	},
+	"scripts": {
+		"fix": "phpcbf",
+		"test": [
+			"parallel-lint . --exclude vendor",
+			"phpcs -p -s"
+		]
+	}
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki"/>
+	<file>.</file>
+	<arg name="extensions" value="php,php5,inc"/>
+	<arg name="encoding" value="utf8"/>
+	<exclude-pattern>vendor/</exclude-pattern>
+        <exclude-pattern>pchart/</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
See #86.

At this point, only the definitions are present:
 * for everyone to apply them and see (`make install-dev && make phpcsfix && make phpcs`),
 * to wait for the right time to merge this PR (that is, there are other PRs that would need to be heavily rebased if merged after this one).

The standard used is Mediawiki's one. I don't... like it much (preference to PSR1 & 2) but being able to check it and fix it automatically with phpcbf is really nice (`make cs` to make sure you don't have errors, `make phpcsfix` to apply automatic corrections).