### PR TITLE
[WIP] Change API endpoint to /rest/

### DIFF
--- a/Bugzilla.php
+++ b/Bugzilla.php
@@ -177,7 +177,7 @@ function BugzillaRender($input, array $args, Parser $parser, $frame=null ) {
  */
 
 // Remote API
-$wgBugzillaRESTURL     = 'https://bugzilla.mozilla.org/bzapi'; // The URL for your Bugzilla API installation
+$wgBugzillaRESTURL     = 'https://bugzilla.mozilla.org/rest/'; // The URL for your Bugzilla API installation
 $wgBugzillaURL         = 'https://bugzilla.mozilla.org'; // The URL for your Bugzilla installation
 $wgBugzillaTagName     = 'bugzilla'; // The tag name for your Bugzilla installation (default: 'bugzilla')
 $wgBugzillaMethod      = 'REST'; // XML-RPC and JSON-RPC may be supported later


### PR DESCRIPTION
See: #83.

Blocking issues at this point:
- [ ] it looks like there is no equivalent in the [REST API](http://bugzilla.readthedocs.io/en/latest/api/) to `GET /bzapi/count?query=` it seems. All charts will be then broken; any idea about this?
- [ ] I am not sure how `generate_chart()` methods are supposed to work. They seem to expect data in this format `{ "data": "1,2,3,4", "'x_labels": "catA,catB,catC,catD" }`. However, `bzapi/count` only returns `{"data": "1234"}` it seems.
