### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
 	"require-dev": {
+		"phpunit/phpunit": "^4.8.36",
 		"jakub-onderka/php-parallel-lint": "0.9.2",
 		"mediawiki/mediawiki-codesniffer": "0.7.2"
 	},

--- a/tests/phpunit/BugzillaQueryTest.php
+++ b/tests/phpunit/BugzillaQueryTest.php
@@ -3,7 +3,9 @@
 require '../../Bugzilla.class.php';
 require '../../BugzillaQuery.class.php';
 
-class BugzillaQueryTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BugzillaQueryTest extends TestCase
 {
     /**
      * @dataProvider prepareOptionsProvider


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Also, bump to PHPUnit [4.8.36](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21) for compatibility.